### PR TITLE
fix: ScriptInvocation had wrong name for args

### DIFF
--- a/src/main/groovy/com/criteo/rundeck/dsl/model/ScriptInvocation.groovy
+++ b/src/main/groovy/com/criteo/rundeck/dsl/model/ScriptInvocation.groovy
@@ -6,7 +6,7 @@ class ScriptInvocation extends Command {
 
     def checker() { return null }
 
-    @YamlProperty(name='scriptargs')
+    @YamlProperty(name='args')
     String args
 
     @YamlProperty(name='scriptinterpreter', merge=true)

--- a/src/test/resources/most_directives.yaml
+++ b/src/test/resources/most_directives.yaml
@@ -64,15 +64,15 @@
       errorhandler:
         keepgoingOnSuccess: true
       exec: echo hello world
-    - description: When several lines are required
+    - args: some
+      description: When several lines are required
       interpreterArgsQuoted: true
       script: |
         for i in hello world; do
           echo $i
         done
-      scriptargs: some
       scriptinterpreter: tcsh
-    - scriptargs: world
+    - args: world
       scriptfile: hello.sh
       scriptinterpreter: zsh
     - interpreterArgsQuoted: true


### PR DESCRIPTION
It is scriptargs in XML and args in YAML (http://rundeck.org/docs/man5/job-yaml.html)